### PR TITLE
Improve annotation

### DIFF
--- a/test/AlienTrimmer.xml
+++ b/test/AlienTrimmer.xml
@@ -24,8 +24,5 @@
   <help><![CDATA[Trimming and Clipping FASTQ-formatted read files
 
 Tool Homepage: https://research.pasteur.fr/en/software/alientrimmer/]]></help>
-  <citations>
-    <citation type="pmid">23912058</citation>
-    <citation type="pmid">24860597</citation>
-  </citations>
+  <citations/>
 </tool>

--- a/test/BMGE.xml
+++ b/test/BMGE.xml
@@ -23,7 +23,5 @@
   <help><![CDATA[Block Mapping and Gathering using Entropy
 
 Tool Homepage: https://research.pasteur.fr/en/software/bmge-block-mapping-and-gathering-with-entropy/]]></help>
-  <citations>
-    <citation type="pmid">20626897</citation>
-  </citations>
+  <citations/>
 </tool>

--- a/test/SARTools.xml
+++ b/test/SARTools.xml
@@ -27,7 +27,5 @@
   <help><![CDATA[SARTools is a R package dedicated to the differential analysis of RNA-seq data. It provides tools to generate descriptive and diagnostic graphs, to run the differential analysis with one of the well known DESeq2 or edgeR packages and to export the results into easily readable tab-delimited files. It also facilitates the generation of a HTML report which displays all the figures produced, explains the statistical methods and gives the results of the differential analysis.
 
 Tool Homepage: https://github.com/PF2-pasteur-fr/SARTools]]></help>
-  <citations>
-    <citation type="pmid">27280887</citation>
-  </citations>
+  <citations/>
 </tool>

--- a/test/SHAMAN.xml
+++ b/test/SHAMAN.xml
@@ -27,7 +27,5 @@
 SHAMAN is based on DESeq2 R package [Anders and Huber 2010] for the analysis of metagenomic data, as suggested in [McMurdie and Holmes 2014, Jonsson2016] . SHAMAN robustly identifies the differential abundant genera with the Generalized Linear Model implemented in DESeq2 [Love 2014] . Resulting p-values are adjusted according to the Benjamini and Hochberg procedure [Benjamini and Hochberg 1995]. The PCOA is performed with the ade4 R package and plots are generated with ggplot2 or D3.js packages. SHAMAN is compatible with standard formats for metagenomic analysis.
 
 Tool Homepage: http://shaman.c3bi.pasteur.fr/]]></help>
-  <citations>
-    <citation type="pmcid">PMC4878514</citation>
-  </citations>
+  <citations/>
 </tool>

--- a/tooldog/annotate/galaxy.py
+++ b/tooldog/annotate/galaxy.py
@@ -85,7 +85,8 @@ class GalaxyToolGen(object):
         if not hasattr(self.tool, 'edam_topics'):
             # First time we add topics to the tool
             self.tool.edam_topics = gxtp.EdamTopics()
-        self.tool.edam_topics.append(gxtp.EdamTopic(topic.get_edam_id()))
+        if not self.tool.edam_topics.has_topic(topic.get_edam_id()):
+            self.tool.edam_topics.append(gxtp.EdamTopic(topic.get_edam_id()))
 
     def add_edam_operation(self, operation):
         """
@@ -99,7 +100,8 @@ class GalaxyToolGen(object):
         if not hasattr(self.tool, 'edam_operations'):
             # First time we add operations to the tool
             self.tool.edam_operations = gxtp.EdamOperations()
-        self.tool.edam_operations.append(gxtp.EdamOperation(operation.get_edam_id()))
+        if not self.tool.edam_operations.has_operation(operation.get_edam_id()):
+            self.tool.edam_operations.append(gxtp.EdamOperation(operation.get_edam_id()))
 
     def add_input_file(self, input_obj):
         """
@@ -176,11 +178,15 @@ class GalaxyToolGen(object):
             self.tool.citations = gxtp.Citations()
         # Add citation depending the type (doi, pmid...)
         if publication.doi is not None:
-            self.tool.citations.append(gxtp.Citation('doi', publication.doi))
+            if not self.tool.citations.has_citation('doi', publication.doi):
+                self.tool.citations.append(gxtp.Citation('doi', publication.doi))
+        # <citation> only supports doi and bibtex as a type
         elif publication.pmid is not None:
-            self.tool.citations.append(gxtp.Citation('pmid', publication.pmid))
+            # self.tool.citations.append(gxtp.Citation('pmid', publication.pmid))
+            LOGGER.warn('pmid is not supported by <citation>, citation skipped')
         elif publication.pmcid is not None:
-            self.tool.citations.append(gxtp.Citation('pmcid', publication.pmcid))
+            # self.tool.citations.append(gxtp.Citation('pmcid', publication.pmcid))
+            LOGGER.warn('pmcid is not supported by <citation>, citation skipped')
 
     def write_xml(self, out_file=None, index=None, keep_old_command=False):
         """

--- a/tooldog/annotate/galaxy.py
+++ b/tooldog/annotate/galaxy.py
@@ -53,6 +53,13 @@ class GalaxyToolGen(object):
             # Add information about Tooldog version
             self.tool.add_comment("This tool descriptor has been annotated by ToolDog v" +
                                   __version__)
+            # Help if missing or TODO
+            if self.tool.help is None:
+                self.tool.help = biotool.generate_galaxy_help()
+            elif "TODO" in self.tool.help:
+                LOGGER.info("TODO has been found in help, content has been replaced.")
+                self.tool.help = biotool.generate_galaxy_help()
+
         else:
             LOGGER.info("Creating new GalaxyToolGen object...")
             # Initialize GalaxyInfo
@@ -66,8 +73,7 @@ class GalaxyToolGen(object):
             description = biotool.description.split('.')[0] + '.'
             self.tool = gxt.Tool(biotool.name, biotool.tool_id, biotool.version,
                                  description, "COMMAND", version_command="COMMAND --version")
-            self.tool.help = (biotool.description + "\n\nTool Homepage: " +
-                              biotool.homepage)
+            self.tool.help = biotool.generate_galaxy_help()
             #   Add information about Galaxy and EDAM in the XML
             self.tool.add_comment("Information was obtained from the Galaxy instance: " +
                                   self.etog.galaxy_url + " v" +

--- a/tooldog/annotate/galaxy.py
+++ b/tooldog/annotate/galaxy.py
@@ -47,6 +47,9 @@ class GalaxyToolGen(object):
             LOGGER.info("Loading existing XML from " + existing_tool)
             gxp = GalaxyXmlParser()
             self.tool = gxp.import_xml(existing_tool)
+            # Add a description if missing from description
+            if self.tool.root.find('description').text is None:
+                self.tool.root.find('description').text = biotool.description.split('.')[0] + '.'
             # Add information about Tooldog version
             self.tool.add_comment("This tool descriptor has been annotated by ToolDog v" +
                                   __version__)

--- a/tooldog/biotool_model.py
+++ b/tooldog/biotool_model.py
@@ -46,7 +46,7 @@ class Biotool(object):
         self.topics = []    # List of Topic objects
         self.informations = None  # Informations object
 
-    def _generate_galaxy_help(self):
+    def generate_galaxy_help(self):
         """
         Generate a help message from the different informations found on the tool.
 

--- a/tooldog/biotool_model.py
+++ b/tooldog/biotool_model.py
@@ -46,6 +46,23 @@ class Biotool(object):
         self.topics = []    # List of Topic objects
         self.informations = None  # Informations object
 
+    def _generate_galaxy_help(self):
+        """
+        Generate a help message from the different informations found on the tool.
+
+        :return: a help message
+        :rtype: STRING
+        """
+        help_message = "\n\nWhat it is ?\n" + "============\n\n"
+        help_message += self.description + "\n\n"
+        help_message += "External links:\n" + "===============\n\n"
+        help_message += "- Tool homepage_\n"
+        help_message += "- bio.tools_ entry\n\n"
+        help_message += ".. _homepage: " + self.homepage + "\n"
+        help_message += ".. _bio.tools: https://bio.tools/tool/" + self.tool_id
+        return help_message
+        
+
     def set_informations(self, tool_credits, contacts, publications, docs,
                          language, links, download):
         '''

--- a/tooldog/main.py
+++ b/tooldog/main.py
@@ -230,16 +230,13 @@ def write_xml(biotool, outfile=None, galaxy_url=None, edam_url=None, mapping_jso
     biotool_xml = GalaxyToolGen(biotool, galaxy_url=galaxy_url, edam_url=edam_url,
                                 mapping_json=mapping_json, existing_tool=existing_tool)
     # Add EDAM annotation and citations
-    if not getattr(biotool_xml, 'edam_topics', None):
-        for topic in biotool.topics:
-            biotool_xml.add_edam_topic(topic)
-    if not getattr(biotool_xml, 'edam_operations', None):
-        for function in biotool.functions:
-            for operation in function.operations:
-                biotool_xml.add_edam_operation(operation)
-    if not getattr(biotool_xml, 'citations', None):
-        for publi in biotool.informations.publications:
-            biotool_xml.add_citation(publi)
+    for topic in biotool.topics:
+        biotool_xml.add_edam_topic(topic)
+    for function in biotool.functions:
+        for operation in function.operations:
+            biotool_xml.add_edam_operation(operation)
+    for publi in biotool.informations.publications:
+        biotool_xml.add_citation(publi)
     # Add inputs and outputs
     if existing_tool:
         biotool_xml.write_xml(out_file=outfile, keep_old_command=True)


### PR DESCRIPTION
The annotation step has been improved.

* Now ToolDog will add only missing edam terms as well as citations.
* Start building method to generate help message from bio.tools information.
* Help message is added if missing from existing tool description.
* Help message is also added if `TODO` is found within the help message.