### PR TITLE
Add inputs outputs annot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 doc/build
 test/__pycache__
+test/update_xml_endtoend.sh
 tooldog/__pycache__
 tooldog/annotate/__pycache__
 tooldog/analyse/__pycache__

--- a/test/AlienTrimmer.xml
+++ b/test/AlienTrimmer.xml
@@ -25,7 +25,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="fastq" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="fastq" from_work_dir="OUTPUT1.fastq" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/AlienTrimmer by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/AlienTrimmer.xml
+++ b/test/AlienTrimmer.xml
@@ -15,11 +15,20 @@
   <command><![CDATA[COMMAND --INPUT1 $INPUT1
 --INPUT2 $INPUT2]]></command>
   <inputs>
-    <param argument="INPUT1" format="fastq" label="DNA sequence (raw)" name="INPUT1" type="data"/>
-    <param argument="INPUT2" format="fasta" label="DNA sequence (raw)" name="INPUT2" type="data"/>
+    <param argument="INPUT1" format="fastq" label="DNA sequence (raw)" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/AlienTrimmer by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
+    <param argument="INPUT2" format="fasta" label="DNA sequence (raw)" name="INPUT2" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/AlienTrimmer by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="fastq" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
+    <data format="fastq" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/AlienTrimmer by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/BMGE.xml
+++ b/test/BMGE.xml
@@ -20,11 +20,11 @@
     </param>
   </inputs>
   <outputs>
-    <data format="data, data, txt" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="data, data, txt" from_work_dir="OUTPUT1.data, data, txt" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/BMGE by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+    <data format="html" from_work_dir="OUTPUT2.html" hidden="false" name="OUTPUT2">
       <!--This parameter has been automatically generated from https://bio.tools/tool/BMGE by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/BMGE.xml
+++ b/test/BMGE.xml
@@ -14,11 +14,20 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="data, txt" label="Sequence alignment" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="data, txt" label="Sequence alignment" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/BMGE by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="data, data, txt" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
-    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2"/>
+    <data format="data, data, txt" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/BMGE by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/BMGE by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/MEMHDX.xml
+++ b/test/MEMHDX.xml
@@ -22,7 +22,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="data" from_work_dir="OUTPUT1.data" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/MEMHDX by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/MEMHDX.xml
+++ b/test/MEMHDX.xml
@@ -16,10 +16,16 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="tabular" label="Mass spectrometry data" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="tabular" label="Mass spectrometry data" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MEMHDX by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
+    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MEMHDX by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/MacSyFinder1.xml
+++ b/test/MacSyFinder1.xml
@@ -31,19 +31,19 @@
     </param>
   </inputs>
   <outputs>
-    <data format="tabular" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="tabular" from_work_dir="OUTPUT1.tabular" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+    <data format="tabular" from_work_dir="OUTPUT2.tabular" hidden="false" name="OUTPUT2">
       <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3">
+    <data format="tabular" from_work_dir="OUTPUT3.tabular" hidden="false" name="OUTPUT3">
       <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="json" from_work_dir="OUTPUT4.ext" hidden="false" name="OUTPUT4">
+    <data format="json" from_work_dir="OUTPUT4.json" hidden="false" name="OUTPUT4">
       <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/MacSyFinder1.xml
+++ b/test/MacSyFinder1.xml
@@ -17,15 +17,36 @@
 --INPUT2 $INPUT2
 --INPUT3 $INPUT3]]></command>
   <inputs>
-    <param argument="INPUT1" format="txt, fasta" label="Protein sequence record" name="INPUT1" type="data"/>
-    <param argument="INPUT2" format="hmm3" label="Sequence-profile alignment" name="INPUT2" type="data"/>
-    <param argument="INPUT3" format="xml" label="Resource metadata" name="INPUT3" type="data"/>
+    <param argument="INPUT1" format="txt, fasta" label="Protein sequence record" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
+    <param argument="INPUT2" format="hmm3" label="Sequence-profile alignment" name="INPUT2" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
+    <param argument="INPUT3" format="xml" label="Resource metadata" name="INPUT3" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="tabular" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
-    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2"/>
-    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3"/>
-    <data format="json" from_work_dir="OUTPUT4.ext" hidden="false" name="OUTPUT4"/>
+    <data format="tabular" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="json" from_work_dir="OUTPUT4.ext" hidden="false" name="OUTPUT4">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/MacSyFinder2.xml
+++ b/test/MacSyFinder2.xml
@@ -15,7 +15,10 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="json" label="Report" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="json" label="Report" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/MacSyFinder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <help><![CDATA[
 

--- a/test/SARTools.xml
+++ b/test/SARTools.xml
@@ -23,15 +23,15 @@
     </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="data" from_work_dir="OUTPUT1.data" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+    <data format="html" from_work_dir="OUTPUT2.html" hidden="false" name="OUTPUT2">
       <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3">
+    <data format="tabular" from_work_dir="OUTPUT3.tabular" hidden="false" name="OUTPUT3">
       <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/SARTools.xml
+++ b/test/SARTools.xml
@@ -17,12 +17,24 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="tabular" label="Gene expression data" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="tabular" label="Gene expression data" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
-    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2"/>
-    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3"/>
+    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="html" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="tabular" from_work_dir="OUTPUT3.ext" hidden="false" name="OUTPUT3">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SARTools by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/SHAMAN.xml
+++ b/test/SHAMAN.xml
@@ -23,7 +23,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="data" from_work_dir="OUTPUT1.data" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/SHAMAN by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/SHAMAN.xml
+++ b/test/SHAMAN.xml
@@ -17,10 +17,16 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="tabular" label="Report" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="tabular" label="Report" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SHAMAN by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
+    <data format="data" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/SHAMAN by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/integron_finder.xml
+++ b/test/integron_finder.xml
@@ -27,11 +27,11 @@
     </param>
   </inputs>
   <outputs>
-    <data format="genbank" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="genbank" from_work_dir="OUTPUT1.genbank" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/integron_finder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>
-    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+    <data format="tabular" from_work_dir="OUTPUT2.tabular" hidden="false" name="OUTPUT2">
       <!--This parameter has been automatically generated from https://bio.tools/tool/integron_finder by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/integron_finder.xml
+++ b/test/integron_finder.xml
@@ -21,11 +21,20 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="fasta" label="DNA sequence (raw)" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="fasta" label="DNA sequence (raw)" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/integron_finder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="genbank" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
-    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2"/>
+    <data format="genbank" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/integron_finder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
+    <data format="tabular" from_work_dir="OUTPUT2.ext" hidden="false" name="OUTPUT2">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/integron_finder by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/sequana_coverage.xml
+++ b/test/sequana_coverage.xml
@@ -21,7 +21,7 @@
     </param>
   </inputs>
   <outputs>
-    <data format="html" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+    <data format="html" from_work_dir="OUTPUT1.html" hidden="false" name="OUTPUT1">
       <!--This parameter has been automatically generated from https://bio.tools/tool/sequana_coverage by ToolDog v0.3.0.-->
       <!--FIXME: Please map this parameter to its command line argument.-->
     </data>

--- a/test/sequana_coverage.xml
+++ b/test/sequana_coverage.xml
@@ -15,10 +15,16 @@
   <version_command>COMMAND --version</version_command>
   <command><![CDATA[COMMAND --INPUT1 $INPUT1]]></command>
   <inputs>
-    <param argument="INPUT1" format="bam, bed, tabular" label="Position-specific scoring matrix" name="INPUT1" type="data"/>
+    <param argument="INPUT1" format="bam, bed, tabular" label="Position-specific scoring matrix" name="INPUT1" type="data">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/sequana_coverage by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </param>
   </inputs>
   <outputs>
-    <data format="html" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1"/>
+    <data format="html" from_work_dir="OUTPUT1.ext" hidden="false" name="OUTPUT1">
+      <!--This parameter has been automatically generated from https://bio.tools/tool/sequana_coverage by ToolDog v0.3.0.-->
+      <!--FIXME: Please map this parameter to its command line argument.-->
+    </data>
   </outputs>
   <help><![CDATA[
 

--- a/test/test_unit_tooldog.py
+++ b/test/test_unit_tooldog.py
@@ -383,7 +383,7 @@ class TestGalaxyToolGen(unittest.TestCase):
         output_attrib = self.genxml.tool.outputs.children[0].node.attrib
         self.assertEqual(output_attrib['name'], 'OUTPUT1')
         self.assertEqual(output_attrib['format'], 'fastq')
-        self.assertEqual(output_attrib['from_work_dir'], 'OUTPUT1.ext')
+        self.assertEqual(output_attrib['from_work_dir'], 'OUTPUT1.fastq')
 
     def test_add_citation(self):
         # Create a Publication object

--- a/tooldog/annotate/galaxy.py
+++ b/tooldog/annotate/galaxy.py
@@ -179,7 +179,8 @@ class GalaxyToolGen(object):
                                                            edam_format=format_uri))
         formats = ', '.join(list_formats)
         # Create the parameter
-        param = gxtp.OutputData(name, format=formats, from_work_dir=name + '.ext')
+        param = gxtp.OutputData(name, format=formats, from_work_dir=name +\
+                                "." + formats.replace('.','/'))
         param.command_line_override = ''
         # Write comment about this param
         param.node.insert(0, etree.Comment(FIXME))

--- a/tooldog/main.py
+++ b/tooldog/main.py
@@ -70,6 +70,11 @@ def parse_arguments():
                            help='Language of the tool.')
     analy_opt.add_argument('--source_code', dest='SOURCE',
                            help='Path the source code directory.')
+    # Group for annotation options
+    annot_opt = parser.add_argument_group('Options for tool description annotation')
+    annot_opt.add_argument('--inout_biotools', action='store_true',
+                           help='add inputs and outputs described in bio.tools to the description',
+                           dest='INOUT_BIOT', default=False)
     # Group for Galaxy options
     galaxy_opt = parser.add_argument_group('Options for Galaxy XML generation (-g/--galaxy)')
     galaxy_opt.add_argument('--galaxy_url', dest='GAL_URL',
@@ -219,7 +224,7 @@ def json_to_biotool(json_file):
 
 
 def write_xml(biotool, outfile=None, galaxy_url=None, edam_url=None, mapping_json=None,
-              existing_tool=None):
+              existing_tool=None, inout_biotool=False):
     """
     This function uses :class:`tooldog.galaxy.GalaxyToolGen` to write XML using galaxyxml.
 
@@ -241,6 +246,12 @@ def write_xml(biotool, outfile=None, galaxy_url=None, edam_url=None, mapping_jso
         biotool_xml.add_citation(publi)
     # Add inputs and outputs
     if existing_tool:
+        if inout_biotool:
+            for function in biotool.functions:
+                for inpt in function.inputs:
+                    biotool_xml.add_input_file(inpt)
+                for output in function.outputs:
+                    biotool_xml.add_output_file(output)
         biotool_xml.write_xml(out_file=outfile, keep_old_command=True)
     else:
         # This will need to be changed when incorporating argparse2tool...
@@ -303,7 +314,7 @@ def annotate(biotool, args, existing_desc=None):
         # Probably need to check if existing_desc right format
         write_xml(biotool, outfile=args.OUTFILE, galaxy_url=args.GAL_URL,
                   edam_url=args.EDAM_URL, mapping_json=args.MAP_FILE,
-                  existing_tool=existing_desc)
+                  existing_tool=existing_desc, inout_biotool=args.INOUT_BIOT)
     elif args.CWL:
         # Write corresponding CWL
         write_cwl(biotool, args.OUTFILE, existing_tool=existing_desc)


### PR DESCRIPTION
Add new argument `--inout_biotools` that allow adding inputs and outputs generated from bio.tools to an existing description.
Comments were also added to all generated inputs and outputs with the `FIXME` tag and a message telling the user to complete the description. A reminder of the version of ToolDog used as well as the source on bio.tools is mentionned.